### PR TITLE
Add internationalization (i18n) support

### DIFF
--- a/INTERNATIONALIZATION.md
+++ b/INTERNATIONALIZATION.md
@@ -1,0 +1,162 @@
+# Internationalization (i18n) Implementation
+
+## Overview
+Logger++ now supports internationalization, allowing the user interface to be displayed in multiple languages.
+
+## Implementation Details
+
+### Core Infrastructure
+- **Messages Utility Class**: `src/main/java/com/nccgroup/loggerplusplus/i18n/Messages.java`
+  - Manages ResourceBundle loading and string retrieval
+  - Supports locale switching at runtime
+  - Provides formatted message support with parameter substitution
+
+### Resource Bundles
+Location: `src/main/resources/i18n/`
+- `messages.properties` - Default English translations
+- `messages_es.properties` - Spanish translations
+- Additional languages can be added by creating `messages_[locale].properties` files
+
+### Supported Locales
+Currently supported:
+- English (default)
+- Spanish (es)
+- French (fr) - framework ready
+- German (de) - framework ready
+- Japanese (ja) - framework ready
+- Simplified Chinese (zh_CN) - framework ready
+- Portuguese Brazil (pt_BR) - framework ready
+
+### Internationalized Components
+The following UI components have been fully internationalized:
+
+1. **PreferencesPanel** (`src/main/java/com/nccgroup/loggerplusplus/preferences/PreferencesPanel.java`)
+   - Status panel
+   - Log filter controls
+   - Tool selection checkboxes
+   - Import/export options
+   - Settings panels
+   - Dialog messages
+
+2. **LoggerMenu** (`src/main/java/com/nccgroup/loggerplusplus/util/userinterface/LoggerMenu.java`)
+   - Color filters menu
+   - View layout options
+   - Request/Response view options
+   - Log level menu
+
+3. **AboutPanel** (`src/main/java/com/nccgroup/loggerplusplus/about/AboutPanel.java`)
+   - Application title and subtitle
+   - Social media buttons
+   - GitHub action buttons
+   - Credits and version information
+   - Features list
+   - Acknowledgements
+
+## Usage
+
+### Accessing Translated Strings
+```java
+import com.nccgroup.loggerplusplus.i18n.Messages;
+
+// Simple string retrieval
+String title = Messages.getString("app.name");
+
+// With parameter substitution
+String status = Messages.getString("status.running", appName);
+```
+
+### Changing Locale (Runtime)
+```java
+import com.nccgroup.loggerplusplus.i18n.Messages;
+import java.util.Locale;
+
+// Set to Spanish
+Messages.setLocale(new Locale("es"));
+
+// Set to French
+Messages.setLocale(new Locale("fr"));
+```
+
+### Getting Supported Locales
+```java
+Locale[] supported = Messages.getSupportedLocales();
+```
+
+## Adding New Languages
+
+To add support for a new language:
+
+1. Create a new properties file: `src/main/resources/i18n/messages_[locale].properties`
+2. Copy the content from `messages.properties`
+3. Translate all values (keep keys in English)
+4. Add the locale to `Messages.getSupportedLocales()` method
+5. Test the translation by setting the locale
+
+## Adding New Translatable Strings
+
+When adding new UI strings:
+
+1. Add the key-value pair to all language properties files
+2. Use `Messages.getString("your.key")` instead of hardcoded strings
+3. For strings with parameters, use `Messages.getString("your.key", param1, param2)`
+
+Example:
+```properties
+# messages.properties
+dialog.confirm.delete=Are you sure you want to delete {0} items?
+```
+
+```java
+String message = Messages.getString("dialog.confirm.delete", itemCount);
+```
+
+## Best Practices
+
+1. **Keep keys semantic**: Use descriptive keys like `menu.view.horizontal` instead of generic ones
+2. **Group related keys**: Use prefixes to organize keys (e.g., `about.*`, `menu.*`, `import.*`)
+3. **Preserve parameter order**: When translating, ensure {0}, {1}, etc. are in the correct position for the target language
+4. **Test translations**: Verify UI layout with longer translated strings
+5. **Handle special characters**: Use Unicode escapes (\u0020 for space, \n for newline)
+
+## Future Enhancements
+
+Potential improvements for future versions:
+
+1. **Runtime Language Switching**: Add UI to change language without restart
+2. **Locale Persistence**: Save user's locale preference
+3. **UI Refresh**: Implement dynamic UI updates when locale changes
+4. **Column Headers**: Internationalize table column names
+5. **Log Entry Fields**: Translate field descriptions
+6. **Community Translations**: Set up Crowdin or similar for community contributions
+
+## Impact
+
+### Modified Files
+- Created: `src/main/java/com/nccgroup/loggerplusplus/i18n/Messages.java`
+- Created: `src/main/resources/i18n/messages.properties`
+- Created: `src/main/resources/i18n/messages_es.properties`
+- Modified: `src/main/java/com/nccgroup/loggerplusplus/preferences/PreferencesPanel.java`
+- Modified: `src/main/java/com/nccgroup/loggerplusplus/util/userinterface/LoggerMenu.java`
+- Modified: `src/main/java/com/nccgroup/loggerplusplus/about/AboutPanel.java`
+
+### Backward Compatibility
+All changes are backward compatible. Existing installations will use English (default) strings automatically.
+
+### Performance Impact
+Minimal - ResourceBundle uses efficient caching, string lookups are O(1).
+
+## Testing
+
+To test the implementation:
+
+1. Build the extension: `./gradlew build`
+2. Load the extension in Burp Suite
+3. Verify all UI strings display correctly
+4. (Optional) Test locale switching programmatically
+5. Verify Spanish translations work correctly
+
+## Resources
+
+- Java ResourceBundle documentation: https://docs.oracle.com/javase/tutorial/i18n/resbundle/index.html
+- Unicode character reference: https://www.unicode.org/charts/
+- Locale codes: https://www.oracle.com/java/technologies/javase/jdk8-jre8-suported-locales.html

--- a/src/main/java/com/nccgroup/loggerplusplus/about/AboutPanel.java
+++ b/src/main/java/com/nccgroup/loggerplusplus/about/AboutPanel.java
@@ -18,6 +18,7 @@ import com.coreyd97.BurpExtenderUtilities.Preferences;
 import com.nccgroup.loggerplusplus.util.Globals;
 import com.nccgroup.loggerplusplus.util.userinterface.NoTextSelectionCaret;
 import com.nccgroup.loggerplusplus.util.userinterface.WrappedTextPane;
+import com.nccgroup.loggerplusplus.i18n.Messages;
 
 import javax.swing.*;
 import javax.swing.text.Style;
@@ -64,13 +65,13 @@ public class AboutPanel extends JPanel {
 	}
 
 	private JComponent buildMainPanel(){
-		JLabel headerLabel = new JLabel("Logger++");
+		JLabel headerLabel = new JLabel(Messages.getString("app.name"));
 		Font font = this.getFont().deriveFont(32f).deriveFont(this.getFont().getStyle() | Font.BOLD);
 		headerLabel.setFont(font);
 		headerLabel.setHorizontalAlignment(SwingConstants.CENTER);
 
 
-		JLabel subtitle = new JLabel("Advanced multithreaded logging tool");
+		JLabel subtitle = new JLabel(Messages.getString("app.subtitle"));
 		Font subtitleFont = subtitle.getFont().deriveFont(16f).deriveFont(subtitle.getFont().getStyle() | Font.ITALIC);
 		subtitle.setFont(subtitleFont);
 		subtitle.setHorizontalAlignment(SwingConstants.CENTER);
@@ -82,11 +83,11 @@ public class AboutPanel extends JPanel {
 		BufferedImage twitterImage = loadImage("TwitterLogo.png");
 		JButton twitterButton;
 		if(twitterImage != null){
-			twitterButton = new JButton("Follow me (@CoreyD97) on Twitter", new ImageIcon(scaleImageToWidth(twitterImage, 20)));
+			twitterButton = new JButton(Messages.getString("about.twitter.corey"), new ImageIcon(scaleImageToWidth(twitterImage, 20)));
 			twitterButton.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
 			twitterButton.setIconTextGap(7);
 		}else{
-			twitterButton = new JButton("Follow me (@CoreyD97) on Twitter");
+			twitterButton = new JButton(Messages.getString("about.twitter.corey"));
 		}
 
 		twitterButton.setMaximumSize(new Dimension(0, 10));
@@ -99,11 +100,11 @@ public class AboutPanel extends JPanel {
 
 		JButton irsdlTwitterButton;
 		if(twitterImage != null){
-			irsdlTwitterButton = new JButton("Follow Soroush (@irsdl) on Twitter", new ImageIcon(scaleImageToWidth(twitterImage, 20)));
+			irsdlTwitterButton = new JButton(Messages.getString("about.twitter.irsdl"), new ImageIcon(scaleImageToWidth(twitterImage, 20)));
 			irsdlTwitterButton.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
 			irsdlTwitterButton.setIconTextGap(7);
 		}else{
-			irsdlTwitterButton = new JButton("Follow Soroush (@irsdl) on Twitter");
+			irsdlTwitterButton = new JButton(Messages.getString("about.twitter.irsdl"));
 		}
 
 		irsdlTwitterButton.setMaximumSize(new Dimension(0, 10));
@@ -118,11 +119,11 @@ public class AboutPanel extends JPanel {
 		JButton nccTwitterButton;
 		BufferedImage nccImage = loadImage("NCCGroup.png");
 		if(nccImage != null){
-			nccTwitterButton = new JButton("Follow NCC Group on Twitter", new ImageIcon(scaleImageToWidth(nccImage, 20)));
+			nccTwitterButton = new JButton(Messages.getString("about.twitter.ncc"), new ImageIcon(scaleImageToWidth(nccImage, 20)));
 			nccTwitterButton.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
 			nccTwitterButton.setIconTextGap(7);
 		}else{
-			nccTwitterButton = new JButton("Follow NCC Group on Twitter");
+			nccTwitterButton = new JButton(Messages.getString("about.twitter.ncc"));
 		}
 
 		nccTwitterButton.addActionListener(actionEvent -> {
@@ -138,15 +139,15 @@ public class AboutPanel extends JPanel {
 		JButton submitFeatureRequestButton;
 		JButton reportBugButton;
 		if(githubImage != null){
-			submitFeatureRequestButton = new JButton("Submit Feature Request", new ImageIcon(scaleImageToWidth(githubImage, 20)));
+			submitFeatureRequestButton = new JButton(Messages.getString("about.github.feature"), new ImageIcon(scaleImageToWidth(githubImage, 20)));
 			submitFeatureRequestButton.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
 			submitFeatureRequestButton.setIconTextGap(7);
-			reportBugButton = new JButton("Report an Issue", new ImageIcon(scaleImageToWidth(githubImage, 20)));
+			reportBugButton = new JButton(Messages.getString("about.github.bug"), new ImageIcon(scaleImageToWidth(githubImage, 20)));
 			reportBugButton.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
 			reportBugButton.setIconTextGap(7);
 		}else{
-			submitFeatureRequestButton = new JButton("Submit Feature Request");
-			reportBugButton = new JButton("Report an Issue");
+			submitFeatureRequestButton = new JButton(Messages.getString("about.github.feature"));
+			reportBugButton = new JButton(Messages.getString("about.github.bug"));
 		}
 
 		submitFeatureRequestButton.addActionListener(actionEvent -> {
@@ -174,13 +175,13 @@ public class AboutPanel extends JPanel {
 			}
 		});
 
-		JLabel createdBy = new JLabel("Developed by: Corey Arthur ( @CoreyD97 )");
+		JLabel createdBy = new JLabel(Messages.getString("about.developed"));
 		createdBy.setHorizontalAlignment(SwingConstants.CENTER);
 		createdBy.setBorder(BorderFactory.createEmptyBorder(0, 0, 7, 0));
-		JLabel ideaBy = new JLabel("Originally by: Soroush Dalili ( @irsdl )");
+		JLabel ideaBy = new JLabel(Messages.getString("about.original"));
 		ideaBy.setHorizontalAlignment(SwingConstants.CENTER);
 		ideaBy.setBorder(BorderFactory.createEmptyBorder(0, 0, 7, 0));
-		JLabel version = new JLabel("Version: " + Globals.VERSION);
+		JLabel version = new JLabel(Messages.getString("app.version", Globals.VERSION));
 		version.setBorder(BorderFactory.createEmptyBorder(0, 0, 7, 0));
 		version.setHorizontalAlignment(SwingConstants.CENTER);
 		JPanel creditsPanel = new PanelBuilder().setComponentGrid(new JComponent[][]{
@@ -211,20 +212,11 @@ public class AboutPanel extends JPanel {
 
 
 		try {
-			String featuresTitle = "Features\n\n";
-			String features = " \u2022 Log requests from all tools\n" +
-					" \u2022 Define filters to search requests\n" +
-					" \u2022 Create rules to highlight interesting requests\n" +
-					" \u2022 Grep all entries for regex patterns and extract matching groups\n" +
-					" \u2022 Import entries from WStalker, OWASP ZAP\n" +
-					" \u2022 Export entries to elasticsearch, CSV\n" +
-					" \u2022 Multithreaded\n\n" +
-					"Want a feature implementing? Make a request using the buttons above!\n" +
-					"Want to help improve Logger++? Submit a pull request!\n\n" +
-					"Like the extension? Let me know by giving it a star on GitHub.\n\n";
+			String featuresTitle = Messages.getString("about.features.title") + "\n\n";
+			String features = Messages.getString("about.features.list") + "\n\n";
 
-			String thanksTo = "Thanks To:\n";
-			String thanksText = "Shaddy, ours-code, jselvi, jaesbit, wotgl, StanHVA, theblackturtle, cnotin, latacora-tomekr, JulianVolodia, jm-syn";
+			String thanksTo = Messages.getString("about.thanks.title") + "\n";
+			String thanksText = Messages.getString("about.thanks.list");
 
 			String[] sections = new String[]{featuresTitle, features, thanksTo, thanksText};
 			Style[] styles = new Style[]{bold, null, null, italics};

--- a/src/main/java/com/nccgroup/loggerplusplus/i18n/Messages.java
+++ b/src/main/java/com/nccgroup/loggerplusplus/i18n/Messages.java
@@ -1,0 +1,92 @@
+package com.nccgroup.loggerplusplus.i18n;
+
+import java.text.MessageFormat;
+import java.util.Locale;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
+
+/**
+ * Internationalization utility class for Logger++
+ * Manages resource bundles and provides access to localized strings
+ */
+public class Messages {
+    private static final String BUNDLE_NAME = "i18n.messages";
+    private static ResourceBundle resourceBundle;
+    private static Locale currentLocale;
+
+    static {
+        // Initialize with default locale (English)
+        currentLocale = Locale.ENGLISH;
+        resourceBundle = ResourceBundle.getBundle(BUNDLE_NAME, currentLocale);
+    }
+
+    /**
+     * Gets a localized string for the given key
+     * @param key The resource bundle key
+     * @return The localized string, or the key itself if not found
+     */
+    public static String getString(String key) {
+        try {
+            return resourceBundle.getString(key);
+        } catch (MissingResourceException e) {
+            // Return the key itself if translation is missing
+            return '!' + key + '!';
+        }
+    }
+
+    /**
+     * Gets a localized string with parameter substitution
+     * @param key The resource bundle key
+     * @param args Arguments to substitute into the message
+     * @return The formatted localized string
+     */
+    public static String getString(String key, Object... args) {
+        try {
+            String pattern = resourceBundle.getString(key);
+            return MessageFormat.format(pattern, args);
+        } catch (MissingResourceException e) {
+            return '!' + key + '!';
+        }
+    }
+
+    /**
+     * Sets the current locale and reloads the resource bundle
+     * @param locale The new locale to use
+     * @return true if the locale was successfully changed, false otherwise
+     */
+    public static boolean setLocale(Locale locale) {
+        try {
+            ResourceBundle newBundle = ResourceBundle.getBundle(BUNDLE_NAME, locale);
+            resourceBundle = newBundle;
+            currentLocale = locale;
+            return true;
+        } catch (MissingResourceException e) {
+            // If the locale is not supported, keep the current one
+            return false;
+        }
+    }
+
+    /**
+     * Gets the current locale
+     * @return The current locale
+     */
+    public static Locale getCurrentLocale() {
+        return currentLocale;
+    }
+
+    /**
+     * Gets an array of supported locales
+     * @return Array of supported locales
+     */
+    public static Locale[] getSupportedLocales() {
+        return new Locale[] {
+            Locale.ENGLISH,
+            new Locale("es"), // Spanish
+            new Locale("fr"), // French
+            new Locale("de"), // German
+            new Locale("ja"), // Japanese
+            Locale.SIMPLIFIED_CHINESE,
+            new Locale("pt", "BR") // Portuguese (Brazil)
+        };
+    }
+}

--- a/src/main/java/com/nccgroup/loggerplusplus/preferences/PreferencesPanel.java
+++ b/src/main/java/com/nccgroup/loggerplusplus/preferences/PreferencesPanel.java
@@ -32,6 +32,7 @@ import com.nccgroup.loggerplusplus.logview.logtable.LogTableColumn;
 import com.nccgroup.loggerplusplus.logview.logtable.LogTableColumnModel;
 import com.nccgroup.loggerplusplus.util.MoreHelp;
 import com.nccgroup.loggerplusplus.util.userinterface.renderer.TagRenderer;
+import com.nccgroup.loggerplusplus.i18n.Messages;
 
 import javax.swing.*;
 import javax.swing.table.DefaultTableCellRenderer;
@@ -48,7 +49,7 @@ public class PreferencesPanel extends JScrollPane {
 
     private final JToggleButton tglbtnIsEnabled;
     private final JLabel esValueChangeWarning = new JLabel(
-            "Warning: Changing preferences while running will disable the upload service and clear all pending uploads.");
+            Messages.getString("elastic.warning.change"));
 
     /**
      * Create the panel.
@@ -58,8 +59,8 @@ public class PreferencesPanel extends JScrollPane {
         this.preferences = preferencesController.getPreferences();
         this.esValueChangeWarning.setForeground(Color.RED);
 
-        ComponentGroup statusPanel = new ComponentGroup(Orientation.HORIZONTAL, "Status");
-        tglbtnIsEnabled = new JToggleButton(new AbstractAction(APP_NAME + " is running") {
+        ComponentGroup statusPanel = new ComponentGroup(Orientation.HORIZONTAL, Messages.getString("status.title"));
+        tglbtnIsEnabled = new JToggleButton(new AbstractAction(Messages.getString("status.running", APP_NAME)) {
             @Override
             public void actionPerformed(ActionEvent e) {
                 JToggleButton thisButton = (JToggleButton) e.getSource();
@@ -69,13 +70,13 @@ public class PreferencesPanel extends JScrollPane {
         statusPanel.add(tglbtnIsEnabled);
         tglbtnIsEnabled.setSelected(preferences.getSetting(PREF_ENABLED));
 
-        ComponentGroup doNotLogPanel = new ComponentGroup(Orientation.HORIZONTAL, "Log Filter");
+        ComponentGroup doNotLogPanel = new ComponentGroup(Orientation.HORIZONTAL, Messages.getString("logfilter.title"));
         JTextField doNotLogFilterField = new JTextField();
-        doNotLogPanel.add(new JLabel("Do not log entries matching filter: "));
+        doNotLogPanel.add(new JLabel(Messages.getString("logfilter.label")));
         GridBagConstraints gbc = doNotLogPanel.generateNextConstraints(true);
         gbc.weightx = 100;
         doNotLogPanel.add(doNotLogFilterField, gbc);
-        JToggleButton applyButton = new JToggleButton(new AbstractAction("Enable") {
+        JToggleButton applyButton = new JToggleButton(new AbstractAction(Messages.getString("logfilter.enable")) {
             @Override
             public void actionPerformed(ActionEvent e) {
                 JToggleButton thisButton = (JToggleButton) e.getSource();
@@ -85,15 +86,15 @@ public class PreferencesPanel extends JScrollPane {
                         doNotLogFilterField.setText(expression.toString());
                         preferences.setSetting(PREF_DO_NOT_LOG_IF_MATCH, expression);
                         doNotLogFilterField.setEnabled(false);
-                        thisButton.setText("Disable");
+                        thisButton.setText(Messages.getString("logfilter.disable"));
                     } catch (ParseException ex) {
-                        JOptionPane.showMessageDialog(thisButton, "Could not parse filter: " + ex.getMessage());
+                        JOptionPane.showMessageDialog(thisButton, Messages.getString("logfilter.parse.error", ex.getMessage()));
                         thisButton.setSelected(false);
                     }
                 }else{
                     preferences.setSetting(PREF_DO_NOT_LOG_IF_MATCH, null);
                     doNotLogFilterField.setEnabled(true);
-                    thisButton.setText("Enable");
+                    thisButton.setText(Messages.getString("logfilter.enable"));
                 }
             }
         });
@@ -105,20 +106,20 @@ public class PreferencesPanel extends JScrollPane {
         doNotLogPanel.add(applyButton);
 
 
-        ComponentGroup logFromPanel = new ComponentGroup(Orientation.VERTICAL, "Log From");
-        logFromPanel.addPreferenceComponent(preferences, PREF_RESTRICT_TO_SCOPE, "In scope items only");
+        ComponentGroup logFromPanel = new ComponentGroup(Orientation.VERTICAL, Messages.getString("logfrom.title"));
+        logFromPanel.addPreferenceComponent(preferences, PREF_RESTRICT_TO_SCOPE, Messages.getString("logfrom.scope"));
         GridBagConstraints strutConstraints = logFromPanel.generateNextConstraints(true);
         strutConstraints.weighty = strutConstraints.weightx = 0;
         logFromPanel.add(Box.createVerticalStrut(10), strutConstraints);
-        JCheckBox logAllTools = logFromPanel.addPreferenceComponent(preferences, PREF_LOG_GLOBAL, "All Tools");
-        JCheckBox logSpider = logFromPanel.addPreferenceComponent(preferences, PREF_LOG_SPIDER, "Spider");
-        JCheckBox logIntruder = logFromPanel.addPreferenceComponent(preferences, PREF_LOG_INTRUDER, "Intruder");
-        JCheckBox logScanner = logFromPanel.addPreferenceComponent(preferences, PREF_LOG_SCANNER, "Scanner");
-        JCheckBox logRepeater = logFromPanel.addPreferenceComponent(preferences, PREF_LOG_REPEATER, "Repeater");
-        JCheckBox logSequencer = logFromPanel.addPreferenceComponent(preferences, PREF_LOG_SEQUENCER, "Sequencer");
-        JCheckBox logProxy = logFromPanel.addPreferenceComponent(preferences, PREF_LOG_PROXY, "Proxy");
-        JCheckBox logTarget = logFromPanel.addPreferenceComponent(preferences, PREF_LOG_TARGET_TAB, "Target");
-        JCheckBox logExtender = logFromPanel.addPreferenceComponent(preferences, PREF_LOG_EXTENSIONS, "Extender");
+        JCheckBox logAllTools = logFromPanel.addPreferenceComponent(preferences, PREF_LOG_GLOBAL, Messages.getString("logfrom.alltools"));
+        JCheckBox logSpider = logFromPanel.addPreferenceComponent(preferences, PREF_LOG_SPIDER, Messages.getString("logfrom.spider"));
+        JCheckBox logIntruder = logFromPanel.addPreferenceComponent(preferences, PREF_LOG_INTRUDER, Messages.getString("logfrom.intruder"));
+        JCheckBox logScanner = logFromPanel.addPreferenceComponent(preferences, PREF_LOG_SCANNER, Messages.getString("logfrom.scanner"));
+        JCheckBox logRepeater = logFromPanel.addPreferenceComponent(preferences, PREF_LOG_REPEATER, Messages.getString("logfrom.repeater"));
+        JCheckBox logSequencer = logFromPanel.addPreferenceComponent(preferences, PREF_LOG_SEQUENCER, Messages.getString("logfrom.sequencer"));
+        JCheckBox logProxy = logFromPanel.addPreferenceComponent(preferences, PREF_LOG_PROXY, Messages.getString("logfrom.proxy"));
+        JCheckBox logTarget = logFromPanel.addPreferenceComponent(preferences, PREF_LOG_TARGET_TAB, Messages.getString("logfrom.target"));
+        JCheckBox logExtender = logFromPanel.addPreferenceComponent(preferences, PREF_LOG_EXTENSIONS, Messages.getString("logfrom.extender"));
 
         strutConstraints = logFromPanel.generateNextConstraints(true);
         strutConstraints.weighty = strutConstraints.weightx = 0;
@@ -150,31 +151,28 @@ public class PreferencesPanel extends JScrollPane {
             logExtender.setEnabled(globalDisabled);
         });
 
-        ComponentGroup importGroup = new ComponentGroup(Orientation.VERTICAL, "Import");
+        ComponentGroup importGroup = new ComponentGroup(Orientation.VERTICAL, Messages.getString("import.title"));
         importGroup.addPreferenceComponent(preferences, PREF_AUTO_IMPORT_PROXY_HISTORY,
-                "Import proxy history on startup");
-        importGroup.add(new JButton(new AbstractAction("Import Burp Proxy History") {
+                Messages.getString("import.autoimport"));
+        importGroup.add(new JButton(new AbstractAction(Messages.getString("import.burphistory")) {
             @Override
             public void actionPerformed(ActionEvent e) {
                 int historySize = LoggerPlusPlus.montoya.proxy().history().size();
                 int maxEntries = preferences.getSetting(PREF_MAXIMUM_ENTRIES);
-                String message = "Import " + historySize
-                        + " items from burp suite proxy history? This will clear the current entries."
-                        + "\nLarge imports may take a few minutes to process.";
+                String message = Messages.getString("import.burphistory.message", historySize);
                 if (historySize > maxEntries) {
-                    message += "\nNote: History will be truncated to " + maxEntries + " entries.";
+                    message += "\n" + Messages.getString("import.burphistory.truncate", maxEntries);
                 }
 
-                int result = MoreHelp.askConfirmMessage("Burp Proxy Import", message,
-                        new String[] { "Import", "Cancel" });
+                int result = MoreHelp.askConfirmMessage(Messages.getString("import.burphistory.title"), message,
+                        new String[] { Messages.getString("import.burphistory.buttons.import"), Messages.getString("import.burphistory.buttons.cancel") });
 
                 if (result == JOptionPane.OK_OPTION) {
                     boolean sendToAutoExporters = false;
                     if (LoggerPlusPlus.instance.getExportController().getEnabledExporters().size() > 0) {
                         int res = JOptionPane.showConfirmDialog(LoggerPlusPlus.instance.getLoggerFrame(),
-                                "One or more auto-exporters are currently enabled. " +
-                                        "Do you want the imported entries to also be sent to the auto-exporters?",
-                                "Auto-exporters Enabled", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+                                Messages.getString("import.autoexporter.message"),
+                                Messages.getString("import.autoexporter.title"), JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
                         sendToAutoExporters = res == JOptionPane.YES_OPTION;
                     }
 
@@ -183,15 +181,14 @@ public class PreferencesPanel extends JScrollPane {
             }
         }));
 
-        importGroup.add(new JButton(new AbstractAction("Import From WStalker CSV") {
+        importGroup.add(new JButton(new AbstractAction(Messages.getString("import.wstalker")) {
             @Override
             public void actionPerformed(ActionEvent e) {
                 ArrayList<HttpRequestResponse> requests = LoggerImport.importWStalker();
                 if (LoggerPlusPlus.instance.getExportController().getEnabledExporters().size() > 0) {
                     int res = JOptionPane.showConfirmDialog(LoggerPlusPlus.instance.getLoggerFrame(),
-                            "One or more auto-exporters are currently enabled. " +
-                                    "Do you want the imported entries to also be sent to the auto-exporters?",
-                            "Auto-exporters Enabled", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+                            Messages.getString("import.autoexporter.message"),
+                            Messages.getString("import.autoexporter.title"), JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
                     LoggerImport.loadImported(requests, res == JOptionPane.YES_OPTION);
                 } else {
                     LoggerImport.loadImported(requests, false);
@@ -199,40 +196,38 @@ public class PreferencesPanel extends JScrollPane {
             }
         }));
 
-        importGroup.add(new JButton(new AbstractAction("Import From OWASP ZAP") {
+        importGroup.add(new JButton(new AbstractAction(Messages.getString("import.zap")) {
             @Override
             public void actionPerformed(ActionEvent e) {
                 ArrayList<HttpRequestResponse> requests;
                 try{
                     requests = LoggerImport.importZAP();
                 } catch (Exception ex){
-                    JOptionPane.showMessageDialog(LoggerPlusPlus.instance.getLoggerFrame(), "Could not import ZAP entries. Exception: \n" + ex.getMessage(), "ZAP Import Failed", JOptionPane.ERROR_MESSAGE);
+                    JOptionPane.showMessageDialog(LoggerPlusPlus.instance.getLoggerFrame(), Messages.getString("import.zap.error", ex.getMessage()), Messages.getString("import.zap.error.title"), JOptionPane.ERROR_MESSAGE);
                     return;
                 }
 
                 if (LoggerPlusPlus.instance.getExportController().getEnabledExporters().size() > 0) {
                     int res = JOptionPane.showConfirmDialog(LoggerPlusPlus.instance.getLoggerFrame(),
-                            "One or more auto-exporters are currently enabled. " +
-                                    "Do you want the imported entries to also be sent to the auto-exporters?",
-                            "Auto-exporters Enabled", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+                            Messages.getString("import.autoexporter.message"),
+                            Messages.getString("import.autoexporter.title"), JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
                     LoggerImport.loadImported(requests, res == JOptionPane.YES_OPTION);
                 } else {
                     LoggerImport.loadImported(requests, false);
                 }
 
-                JOptionPane.showMessageDialog(LoggerPlusPlus.instance.getLoggerFrame(), requests.size() + " ZAP entries imported successfully", "ZAP Import", JOptionPane.INFORMATION_MESSAGE);
+                JOptionPane.showMessageDialog(LoggerPlusPlus.instance.getLoggerFrame(), Messages.getString("import.zap.success", requests.size()), Messages.getString("import.zap.success.title"), JOptionPane.INFORMATION_MESSAGE);
             }
         }));
 
-        importGroup.add(new JButton(new AbstractAction("Import From Exported JSON") {
+        importGroup.add(new JButton(new AbstractAction(Messages.getString("import.json")) {
             @Override
             public void actionPerformed(ActionEvent e) {
                 ArrayList<HttpRequestResponse> requests = LoggerImport.importFromExportedJson();
                 if (LoggerPlusPlus.instance.getExportController().getEnabledExporters().size() > 0) {
                     int res = JOptionPane.showConfirmDialog(LoggerPlusPlus.instance.getLoggerFrame(),
-                            "One or more auto-exporters are currently enabled. " +
-                                    "Do you want the imported entries to also be sent to the auto-exporters?",
-                            "Auto-exporters Enabled", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+                            Messages.getString("import.autoexporter.message"),
+                            Messages.getString("import.autoexporter.title"), JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
                     LoggerImport.loadImported(requests, res == JOptionPane.YES_OPTION);
                 } else {
                     LoggerImport.loadImported(requests, false);
@@ -248,32 +243,32 @@ public class PreferencesPanel extends JScrollPane {
         exportGroup.add(((ExportPanelProvider) exporters.get(HARExporter.class)).getExportPanel());
         exportGroup.add(((ExportPanelProvider) exporters.get(ElasticExporter.class)).getExportPanel());
 
-        ComponentGroup otherPanel = new ComponentGroup(Orientation.VERTICAL, "Other");
+        ComponentGroup otherPanel = new ComponentGroup(Orientation.VERTICAL, Messages.getString("other.title"));
         JSpinner spnRespTimeout = otherPanel.addPreferenceComponent(preferences, PREF_RESPONSE_TIMEOUT,
-                "Response Timeout (Seconds): ");
+                Messages.getString("other.responsetimeout"));
         ((SpinnerNumberModel) spnRespTimeout.getModel()).setMinimum(10);
         ((SpinnerNumberModel) spnRespTimeout.getModel()).setMaximum(600);
         ((SpinnerNumberModel) spnRespTimeout.getModel()).setStepSize(10);
 
         JSpinner spnMaxEntries = otherPanel.addPreferenceComponent(preferences, PREF_MAXIMUM_ENTRIES,
-                "Maximum Log Entries: ");
+                Messages.getString("other.maxentries"));
         ((SpinnerNumberModel) spnMaxEntries.getModel()).setMinimum(10);
         ((SpinnerNumberModel) spnMaxEntries.getModel()).setMaximum(Integer.MAX_VALUE);
         ((SpinnerNumberModel) spnMaxEntries.getModel()).setStepSize(10);
 
         JSpinner spnSearchThreads = otherPanel.addPreferenceComponent(preferences, PREF_SEARCH_THREADS,
-                "Search Threads: ");
+                Messages.getString("other.searchthreads"));
         ((SpinnerNumberModel) spnSearchThreads.getModel()).setMinimum(1);
         ((SpinnerNumberModel) spnSearchThreads.getModel()).setMaximum(50);
         ((SpinnerNumberModel) spnSearchThreads.getModel()).setStepSize(1);
 
         JSpinner maxResponseSize = otherPanel.addPreferenceComponent(preferences, PREF_MAX_RESP_SIZE,
-                "Maximum Response Size (MB): ");
+                Messages.getString("other.maxrespsize"));
         ((SpinnerNumberModel) maxResponseSize.getModel()).setMinimum(0);
         ((SpinnerNumberModel) maxResponseSize.getModel()).setMaximum(1000000);
         ((SpinnerNumberModel) maxResponseSize.getModel()).setStepSize(1);
 
-        JCheckBox tagStyle = otherPanel.addPreferenceComponent(preferences, PREF_TABLE_PILL_STYLE, "Display matching tags as pill components");
+        JCheckBox tagStyle = otherPanel.addPreferenceComponent(preferences, PREF_TABLE_PILL_STYLE, Messages.getString("other.tagstyle"));
 
         preferences.addSettingListener((source, settingName, newValue) -> {
             if(Objects.equals(settingName, PREF_TABLE_PILL_STYLE)){
@@ -288,11 +283,11 @@ public class PreferencesPanel extends JScrollPane {
             }
         });
 
-        ComponentGroup savedFilterSharing = new ComponentGroup(Orientation.VERTICAL, "Saved Filter Backup");
-        savedFilterSharing.add(new JButton(new AbstractAction("Import Saved Filters") {
+        ComponentGroup savedFilterSharing = new ComponentGroup(Orientation.VERTICAL, Messages.getString("savedfilter.title"));
+        savedFilterSharing.add(new JButton(new AbstractAction(Messages.getString("savedfilter.import")) {
             @Override
             public void actionPerformed(ActionEvent e) {
-                String json = MoreHelp.showLargeInputDialog("Import Saved Filters", null);
+                String json = MoreHelp.showLargeInputDialog(Messages.getString("savedfilter.import"), null);
                 ArrayList<SavedFilter> importedFilters = preferencesController.getGsonProvider().getGson()
                         .fromJson(json, new TypeToken<ArrayList<SavedFilter>>() {
                         }.getType());
@@ -305,20 +300,20 @@ public class PreferencesPanel extends JScrollPane {
             }
         }));
 
-        savedFilterSharing.add(new JButton(new AbstractAction("Export Saved Filters") {
+        savedFilterSharing.add(new JButton(new AbstractAction(Messages.getString("savedfilter.export")) {
             @Override
             public void actionPerformed(ActionEvent e) {
                 ArrayList<SavedFilter> savedFilters = preferences.getSetting(PREF_SAVED_FILTERS);
                 String jsonOutput = preferencesController.getGsonProvider().getGson().toJson(savedFilters);
-                MoreHelp.showLargeOutputDialog("Export Saved Filters", jsonOutput);
+                MoreHelp.showLargeOutputDialog(Messages.getString("savedfilter.export"), jsonOutput);
             }
         }));
 
-        ComponentGroup colorFilterSharing = new ComponentGroup(Orientation.VERTICAL, "Color Filter Backup");
-        colorFilterSharing.add(new JButton(new AbstractAction("Import Color Filters") {
+        ComponentGroup colorFilterSharing = new ComponentGroup(Orientation.VERTICAL, Messages.getString("colorfilter.title"));
+        colorFilterSharing.add(new JButton(new AbstractAction(Messages.getString("colorfilter.import")) {
             @Override
             public void actionPerformed(ActionEvent e) {
-                String json = MoreHelp.showLargeInputDialog("Import Color Filters", null);
+                String json = MoreHelp.showLargeInputDialog(Messages.getString("colorfilter.import"), null);
                 Map<UUID, TableColorRule> colorFilterMap = preferencesController.getGsonProvider().getGson().fromJson(json,
                         new TypeToken<Map<UUID, TableColorRule>>() {
                         }.getType());
@@ -329,20 +324,20 @@ public class PreferencesPanel extends JScrollPane {
             }
         }));
 
-        colorFilterSharing.add(new JButton(new AbstractAction("Export Color Filters") {
+        colorFilterSharing.add(new JButton(new AbstractAction(Messages.getString("colorfilter.export")) {
             @Override
             public void actionPerformed(ActionEvent e) {
                 HashMap<UUID, TableColorRule> colorFilters = preferences.getSetting(PREF_COLOR_FILTERS);
                 String jsonOutput = preferencesController.getGsonProvider().getGson().toJson(colorFilters);
-                MoreHelp.showLargeOutputDialog("Export Color Filters", jsonOutput);
+                MoreHelp.showLargeOutputDialog(Messages.getString("colorfilter.export"), jsonOutput);
             }
         }));
 
-        ComponentGroup tagSharing = new ComponentGroup(Orientation.VERTICAL, "Tag Backup");
-        tagSharing.add(new JButton(new AbstractAction("Import Tags") {
+        ComponentGroup tagSharing = new ComponentGroup(Orientation.VERTICAL, Messages.getString("tag.title"));
+        tagSharing.add(new JButton(new AbstractAction(Messages.getString("tag.import")) {
             @Override
             public void actionPerformed(ActionEvent e) {
-                String json = MoreHelp.showLargeInputDialog("Import Tags", null);
+                String json = MoreHelp.showLargeInputDialog(Messages.getString("tag.import"), null);
                 Map<UUID, Tag> tagMap = preferencesController.getGsonProvider().getGson().fromJson(json,
                         new TypeToken<Map<UUID, Tag>>() {
                         }.getType());
@@ -353,35 +348,35 @@ public class PreferencesPanel extends JScrollPane {
             }
         }));
 
-        tagSharing.add(new JButton(new AbstractAction("Export Tags") {
+        tagSharing.add(new JButton(new AbstractAction(Messages.getString("tag.export")) {
             @Override
             public void actionPerformed(ActionEvent e) {
                 HashMap<UUID, Tag> tags = preferences.getSetting(PREF_TAG_FILTERS);
                 String jsonOutput = preferencesController.getGsonProvider().getGson().toJson(tags);
-                MoreHelp.showLargeOutputDialog("Export Tags", jsonOutput);
+                MoreHelp.showLargeOutputDialog(Messages.getString("tag.export"), jsonOutput);
             }
         }));
 
-        ComponentGroup reflectionsPanel = new ComponentGroup(Orientation.HORIZONTAL, "Reflections");
-        reflectionsPanel.add(new JButton(new AbstractAction("Configure Filters") {
+        ComponentGroup reflectionsPanel = new ComponentGroup(Orientation.HORIZONTAL, Messages.getString("reflections.title"));
+        reflectionsPanel.add(new JButton(new AbstractAction(Messages.getString("reflections.configfilters")) {
             @Override
             public void actionPerformed(ActionEvent e) {
                 LoggerPlusPlus.instance.getReflectionController().showFilterConfigDialog();
             }
         }));
-        reflectionsPanel.add(new JButton(new AbstractAction("Configure Transformation Detectors") {
+        reflectionsPanel.add(new JButton(new AbstractAction(Messages.getString("reflections.configtransform")) {
             @Override
             public void actionPerformed(ActionEvent e) {
                 LoggerPlusPlus.instance.getReflectionController().showValueTransformerDialog();
             }
         }));
 
-        ComponentGroup resetPanel = new ComponentGroup(Orientation.VERTICAL, "Reset");
-        resetPanel.add(new JButton(new AbstractAction("Reset All Settings") {
+        ComponentGroup resetPanel = new ComponentGroup(Orientation.VERTICAL, Messages.getString("reset.title"));
+        resetPanel.add(new JButton(new AbstractAction(Messages.getString("reset.all")) {
             @Override
             public void actionPerformed(ActionEvent e) {
                 int result = JOptionPane.showConfirmDialog(null,
-                        "Are you sure you wish to reset all settings? This includes the table layout!", "Warning",
+                        Messages.getString("reset.all.confirm"), Messages.getString("reset.all.confirm.title"),
                         JOptionPane.YES_NO_OPTION);
                 if (result == JOptionPane.YES_OPTION) {
                     preferences.resetSettings(preferences.getRegisteredSettings().keySet());
@@ -391,21 +386,19 @@ public class PreferencesPanel extends JScrollPane {
             }
         }));
 
-        resetPanel.add(new JButton(new AbstractAction("Clear The Logs") {
+        resetPanel.add(new JButton(new AbstractAction(Messages.getString("reset.clearlogs")) {
             @Override
             public void actionPerformed(ActionEvent e) {
                 LoggerPlusPlus.instance.getLogViewController().getLogTableController().reset();
             }
         }));
 
-        ComponentGroup notesPanel = new ComponentGroup(Orientation.VERTICAL, "Notes");
-        notesPanel.add(new JLabel("Note 0: Right click on columns' headers to change settings."));
-        notesPanel.add(new JLabel("Note 1: Extensive logging  may affect Burp Suite performance."));
-        notesPanel.add(new JLabel(
-                "Note 2: Automatic logging does not saveFilters requests and responses. Only table contents. "));
-        notesPanel.add(
-                new JLabel("Note 3: Full request/response logging available in 'Project Options > Misc > Logging'"));
-        notesPanel.add(new JLabel("Note 4: Updating the extension will reset the log table settings."));
+        ComponentGroup notesPanel = new ComponentGroup(Orientation.VERTICAL, Messages.getString("notes.title"));
+        notesPanel.add(new JLabel(Messages.getString("notes.note0")));
+        notesPanel.add(new JLabel(Messages.getString("notes.note1")));
+        notesPanel.add(new JLabel(Messages.getString("notes.note2")));
+        notesPanel.add(new JLabel(Messages.getString("notes.note3")));
+        notesPanel.add(new JLabel(Messages.getString("notes.note4")));
 
         JPanel mainComponent = new PanelBuilder()
                 .setAlignment(Alignment.TOPMIDDLE)
@@ -426,7 +419,7 @@ public class PreferencesPanel extends JScrollPane {
     }
 
     private void toggleEnabledButton(boolean isSelected) {
-        tglbtnIsEnabled.setText(APP_NAME + (isSelected ? " is running" : " has been stopped"));
+        tglbtnIsEnabled.setText(isSelected ? Messages.getString("status.running", APP_NAME) : Messages.getString("status.stopped", APP_NAME));
         tglbtnIsEnabled.setSelected(isSelected);
         preferences.setSetting(PREF_ENABLED, isSelected);
     }

--- a/src/main/java/com/nccgroup/loggerplusplus/util/userinterface/LoggerMenu.java
+++ b/src/main/java/com/nccgroup/loggerplusplus/util/userinterface/LoggerMenu.java
@@ -5,6 +5,7 @@ import com.coreyd97.BurpExtenderUtilities.VariableViewPanel;
 import com.nccgroup.loggerplusplus.LoggerPlusPlus;
 import com.nccgroup.loggerplusplus.util.Globals;
 import com.nccgroup.loggerplusplus.util.userinterface.dialog.ColorFilterDialog;
+import com.nccgroup.loggerplusplus.i18n.Messages;
 import org.apache.logging.log4j.Level;
 
 import javax.swing.*;
@@ -26,7 +27,7 @@ public class LoggerMenu extends javax.swing.JMenu {
         this.add(loggerPlusPlus.getMainViewController().getPopOutWrapper().getPopoutMenuItem());
         this.add(loggerPlusPlus.getLogViewController().getLogViewPanel().getRequestViewerPanel().getPopoutMenuItem());
 
-        JMenuItem colorFilters = new JMenuItem(new AbstractAction("Color Filters") {
+        JMenuItem colorFilters = new JMenuItem(new AbstractAction(Messages.getString("menu.colorfilters")) {
             @Override
             public void actionPerformed(ActionEvent actionEvent) {
                 new ColorFilterDialog(LoggerPlusPlus.instance.getLibraryController()).setVisible(true);
@@ -34,10 +35,10 @@ public class LoggerMenu extends javax.swing.JMenu {
         });
         this.add(colorFilters);
 
-        JMenu viewMenu = new JMenu("View");
+        JMenu viewMenu = new JMenu(Messages.getString("menu.view"));
         VariableViewPanel.View currentView = preferences.getSetting(Globals.PREF_LAYOUT);
         ButtonGroup bGroup = new ButtonGroup();
-        JRadioButtonMenuItem viewMenuItem = new JRadioButtonMenuItem(new AbstractAction("Top/Bottom Split") {
+        JRadioButtonMenuItem viewMenuItem = new JRadioButtonMenuItem(new AbstractAction(Messages.getString("menu.view.vertical")) {
             @Override
             public void actionPerformed(ActionEvent actionEvent) {
                 loggerPlusPlus.getLogViewController().setPanelLayout(VariableViewPanel.View.VERTICAL);
@@ -46,7 +47,7 @@ public class LoggerMenu extends javax.swing.JMenu {
         viewMenuItem.setSelected(currentView == VariableViewPanel.View.VERTICAL);
         viewMenu.add(viewMenuItem);
         bGroup.add(viewMenuItem);
-        viewMenuItem = new JRadioButtonMenuItem(new AbstractAction("Left/Right Split") {
+        viewMenuItem = new JRadioButtonMenuItem(new AbstractAction(Messages.getString("menu.view.horizontal")) {
             @Override
             public void actionPerformed(ActionEvent actionEvent) {
                 loggerPlusPlus.getLogViewController().setPanelLayout(VariableViewPanel.View.HORIZONTAL);
@@ -55,7 +56,7 @@ public class LoggerMenu extends javax.swing.JMenu {
         viewMenuItem.setSelected(currentView == VariableViewPanel.View.HORIZONTAL);
         viewMenu.add(viewMenuItem);
         bGroup.add(viewMenuItem);
-        viewMenuItem = new JRadioButtonMenuItem(new AbstractAction("Tabs") {
+        viewMenuItem = new JRadioButtonMenuItem(new AbstractAction(Messages.getString("menu.view.tabs")) {
             @Override
             public void actionPerformed(ActionEvent actionEvent) {
                 loggerPlusPlus.getLogViewController().setPanelLayout(VariableViewPanel.View.TABS);
@@ -66,10 +67,10 @@ public class LoggerMenu extends javax.swing.JMenu {
         bGroup.add(viewMenuItem);
         this.add(viewMenu);
 
-        viewMenu = new JMenu("Request/Response View");
+        viewMenu = new JMenu(Messages.getString("menu.reqresp.view"));
         VariableViewPanel.View currentReqRespView = preferences.getSetting(Globals.PREF_MESSAGE_VIEW_LAYOUT);
         bGroup = new ButtonGroup();
-        viewMenuItem = new JRadioButtonMenuItem(new AbstractAction("Top/Bottom Split") {
+        viewMenuItem = new JRadioButtonMenuItem(new AbstractAction(Messages.getString("menu.view.vertical")) {
             @Override
             public void actionPerformed(ActionEvent actionEvent) {
                 loggerPlusPlus.getLogViewController().setEntryViewerLayout(VariableViewPanel.View.VERTICAL);
@@ -78,7 +79,7 @@ public class LoggerMenu extends javax.swing.JMenu {
         viewMenu.add(viewMenuItem);
         bGroup.add(viewMenuItem);
         viewMenuItem.setSelected(currentReqRespView == VariableViewPanel.View.VERTICAL);
-        viewMenuItem = new JRadioButtonMenuItem(new AbstractAction("Left/Right Split") {
+        viewMenuItem = new JRadioButtonMenuItem(new AbstractAction(Messages.getString("menu.view.horizontal")) {
             @Override
             public void actionPerformed(ActionEvent actionEvent) {
                 loggerPlusPlus.getLogViewController().setEntryViewerLayout(VariableViewPanel.View.HORIZONTAL);
@@ -87,7 +88,7 @@ public class LoggerMenu extends javax.swing.JMenu {
         viewMenu.add(viewMenuItem);
         bGroup.add(viewMenuItem);
         viewMenuItem.setSelected(currentReqRespView == VariableViewPanel.View.HORIZONTAL);
-        viewMenuItem = new JRadioButtonMenuItem(new AbstractAction("Tabs") {
+        viewMenuItem = new JRadioButtonMenuItem(new AbstractAction(Messages.getString("menu.view.tabs")) {
             @Override
             public void actionPerformed(ActionEvent actionEvent) {
                 loggerPlusPlus.getLogViewController().setEntryViewerLayout(VariableViewPanel.View.TABS);
@@ -111,7 +112,7 @@ public class LoggerMenu extends javax.swing.JMenu {
 
         logLevelGroup.add(debug);
         logLevelGroup.add(info);
-        JMenu logLevelMenu = new JMenu("Log Level");
+        JMenu logLevelMenu = new JMenu(Messages.getString("menu.loglevel"));
         logLevelMenu.add(debug);
         logLevelMenu.add(info);
 

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -1,0 +1,190 @@
+# Logger++ Internationalization Messages
+# Default language: English
+
+# Application Info
+app.name=Logger++
+app.subtitle=Advanced multithreaded logging tool
+app.version=Version: {0}
+
+# Status Panel
+status.title=Status
+status.running={0} is running
+status.stopped={0} has been stopped
+
+# Log Filter Panel
+logfilter.title=Log Filter
+logfilter.label=Do not log entries matching filter:\u0020
+logfilter.enable=Enable
+logfilter.disable=Disable
+logfilter.parse.error=Could not parse filter: {0}
+
+# Log From Panel
+logfrom.title=Log From
+logfrom.scope=In scope items only
+logfrom.alltools=All Tools
+logfrom.spider=Spider
+logfrom.intruder=Intruder
+logfrom.scanner=Scanner
+logfrom.repeater=Repeater
+logfrom.sequencer=Sequencer
+logfrom.proxy=Proxy
+logfrom.target=Target
+logfrom.extender=Extender
+
+# Import Panel
+import.title=Import
+import.autoimport=Import proxy history on startup
+import.burphistory=Import Burp Proxy History
+import.burphistory.message=Import {0} items from burp suite proxy history? This will clear the current entries.\nLarge imports may take a few minutes to process.
+import.burphistory.truncate=Note: History will be truncated to {0} entries.
+import.burphistory.title=Burp Proxy Import
+import.burphistory.buttons.import=Import
+import.burphistory.buttons.cancel=Cancel
+import.wstalker=Import From WStalker CSV
+import.zap=Import From OWASP ZAP
+import.zap.error=Could not import ZAP entries. Exception: \n{0}
+import.zap.error.title=ZAP Import Failed
+import.zap.success={0} ZAP entries imported successfully
+import.zap.success.title=ZAP Import
+import.json=Import From Exported JSON
+import.autoexporter.message=One or more auto-exporters are currently enabled. Do you want the imported entries to also be sent to the auto-exporters?
+import.autoexporter.title=Auto-exporters Enabled
+
+# Menu Items
+menu.colorfilters=Color Filters
+menu.view=View
+menu.view.vertical=Top/Bottom Split
+menu.view.horizontal=Left/Right Split
+menu.view.tabs=Tabs
+menu.reqresp.view=Request/Response View
+menu.loglevel=Log Level
+
+# Other Settings Panel
+other.title=Other
+other.responsetimeout=Response Timeout (Seconds):\u0020
+other.maxentries=Maximum Log Entries:\u0020
+other.searchthreads=Search Threads:\u0020
+other.maxrespsize=Maximum Response Size (MB):\u0020
+other.tagstyle=Display matching tags as pill components
+
+# Saved Filter Backup Panel
+savedfilter.title=Saved Filter Backup
+savedfilter.import=Import Saved Filters
+savedfilter.export=Export Saved Filters
+
+# Color Filter Backup Panel
+colorfilter.title=Color Filter Backup
+colorfilter.import=Import Color Filters
+colorfilter.export=Export Color Filters
+
+# Tag Backup Panel
+tag.title=Tag Backup
+tag.import=Import Tags
+tag.export=Export Tags
+
+# Reflections Panel
+reflections.title=Reflections
+reflections.configfilters=Configure Filters
+reflections.configtransform=Configure Transformation Detectors
+
+# Reset Panel
+reset.title=Reset
+reset.all=Reset All Settings
+reset.all.confirm=Are you sure you wish to reset all settings? This includes the table layout!
+reset.all.confirm.title=Warning
+reset.clearlogs=Clear The Logs
+
+# Notes Panel
+notes.title=Notes
+notes.note0=Note 0: Right click on columns' headers to change settings.
+notes.note1=Note 1: Extensive logging  may affect Burp Suite performance.
+notes.note2=Note 2: Automatic logging does not saveFilters requests and responses. Only table contents.\u0020
+notes.note3=Note 3: Full request/response logging available in 'Project Options > Misc > Logging'
+notes.note4=Note 4: Updating the extension will reset the log table settings.
+
+# About Panel
+about.developed=Developed by: Corey Arthur ( @CoreyD97 )
+about.original=Originally by: Soroush Dalili ( @irsdl )
+about.twitter.corey=Follow me (@CoreyD97) on Twitter
+about.twitter.irsdl=Follow Soroush (@irsdl) on Twitter
+about.twitter.ncc=Follow NCC Group on Twitter
+about.github.feature=Submit Feature Request
+about.github.bug=Report an Issue
+about.features.title=Features
+about.features.list=\u2022 Log requests from all tools\n\u2022 Define filters to search requests\n\u2022 Create rules to highlight interesting requests\n\u2022 Grep all entries for regex patterns and extract matching groups\n\u2022 Import entries from WStalker, OWASP ZAP\n\u2022 Export entries to elasticsearch, CSV\n\u2022 Multithreaded\n\nWant a feature implementing? Make a request using the buttons above!\nWant to help improve Logger++? Submit a pull request!\n\nLike the extension? Let me know by giving it a star on GitHub.
+about.thanks.title=Thanks To:
+about.thanks.list=Shaddy, ours-code, jselvi, jaesbit, wotgl, StanHVA, theblackturtle, cnotin, latacora-tomekr, JulianVolodia, jm-syn
+
+# Column Headers
+column.number=#
+column.tags=Tags
+column.inscope=In Scope
+column.complete=Complete
+column.tool=Tool
+column.ssl=SSL
+column.method=Method
+column.protocol=Protocol
+column.hostname=Host Name
+column.port=Port
+column.host=Host
+column.path=Path
+column.extension=Extension
+column.query=Query
+column.pathquery=Path Query
+column.url=URL
+column.hasparams=Has Params
+column.status=Status
+column.title=Title
+column.requestlength=Request Length
+column.responselength=Response Length
+column.inferredtype=Inferred Type
+column.comment=Comment
+column.paramcount=Parameter Count
+column.params=Parameters
+column.reflectedparams=Reflected Params
+column.reflectioncount=Reflection Count
+column.origin=Origin header
+column.mimetype=MIME type
+column.newcookies=New Cookies
+column.requesttime=Request Time
+column.responsetime=Response Time
+column.responsehash=Response Hash
+column.rtt=RTT (ms)
+column.listenerinterface=Proxy Listener Interface
+column.clientip=Proxy Client IP
+column.responsecontenttype=Response Content-Type
+column.querystring=Query String?
+column.bodyparams=Body Params?
+column.sentcookie=Sent Cookie?
+column.sentcookies=Sent Cookies
+column.cookiejar=Contains cookie jar?
+column.requesttype=Request Type
+column.referrer=Referrer
+column.redirect=Redirect
+column.setcookie=Set-Cookie?
+column.requestbody=Request Body
+column.requestbodylength=Request Body Length
+column.requestheaders=Request Headers
+column.responsebody=Response Body
+column.responsebodylength=Response Body Length
+column.responseheaders=Response Headers
+
+# Common Buttons
+button.ok=OK
+button.cancel=Cancel
+button.save=Save
+button.delete=Delete
+button.close=Close
+button.enable=Enable
+button.disable=Disable
+button.import=Import
+button.export=Export
+
+# Common Messages
+message.warning=Warning
+message.error=Error
+message.success=Success
+message.confirm=Confirm
+
+# Elastic Exporter Messages
+elastic.warning.change=Warning: Changing preferences while running will disable the upload service and clear all pending uploads.

--- a/src/main/resources/i18n/messages_es.properties
+++ b/src/main/resources/i18n/messages_es.properties
@@ -1,0 +1,190 @@
+# Logger++ Mensajes de Internacionalización
+# Idioma: Español
+
+# Información de la Aplicación
+app.name=Logger++
+app.subtitle=Herramienta avanzada de registro multihilo
+app.version=Versión: {0}
+
+# Panel de Estado
+status.title=Estado
+status.running={0} está ejecutándose
+status.stopped={0} ha sido detenido
+
+# Panel de Filtro de Registro
+logfilter.title=Filtro de Registro
+logfilter.label=No registrar entradas que coincidan con el filtro:\u0020
+logfilter.enable=Activar
+logfilter.disable=Desactivar
+logfilter.parse.error=No se pudo analizar el filtro: {0}
+
+# Panel de Registro Desde
+logfrom.title=Registrar Desde
+logfrom.scope=Solo elementos en el alcance
+logfrom.alltools=Todas las Herramientas
+logfrom.spider=Spider
+logfrom.intruder=Intruder
+logfrom.scanner=Scanner
+logfrom.repeater=Repeater
+logfrom.sequencer=Sequencer
+logfrom.proxy=Proxy
+logfrom.target=Target
+logfrom.extender=Extender
+
+# Panel de Importación
+import.title=Importar
+import.autoimport=Importar historial del proxy al iniciar
+import.burphistory=Importar Historial del Proxy de Burp
+import.burphistory.message=¿Importar {0} elementos del historial del proxy de burp suite? Esto borrará las entradas actuales.\nLas importaciones grandes pueden tardar unos minutos en procesarse.
+import.burphistory.truncate=Nota: El historial se truncará a {0} entradas.
+import.burphistory.title=Importación del Proxy de Burp
+import.burphistory.buttons.import=Importar
+import.burphistory.buttons.cancel=Cancelar
+import.wstalker=Importar Desde CSV de WStalker
+import.zap=Importar Desde OWASP ZAP
+import.zap.error=No se pudieron importar las entradas de ZAP. Excepción: \n{0}
+import.zap.error.title=Importación de ZAP Fallida
+import.zap.success={0} entradas de ZAP importadas exitosamente
+import.zap.success.title=Importación de ZAP
+import.json=Importar Desde JSON Exportado
+import.autoexporter.message=Uno o más auto-exportadores están actualmente habilitados. ¿Desea que las entradas importadas también se envíen a los auto-exportadores?
+import.autoexporter.title=Auto-exportadores Habilitados
+
+# Elementos del Menú
+menu.colorfilters=Filtros de Color
+menu.view=Ver
+menu.view.vertical=División Superior/Inferior
+menu.view.horizontal=División Izquierda/Derecha
+menu.view.tabs=Pestañas
+menu.reqresp.view=Vista de Solicitud/Respuesta
+menu.loglevel=Nivel de Registro
+
+# Panel de Otras Configuraciones
+other.title=Otros
+other.responsetimeout=Tiempo de Espera de Respuesta (Segundos):\u0020
+other.maxentries=Entradas de Registro Máximas:\u0020
+other.searchthreads=Hilos de Búsqueda:\u0020
+other.maxrespsize=Tamaño Máximo de Respuesta (MB):\u0020
+other.tagstyle=Mostrar etiquetas coincidentes como componentes de píldora
+
+# Panel de Respaldo de Filtros Guardados
+savedfilter.title=Respaldo de Filtros Guardados
+savedfilter.import=Importar Filtros Guardados
+savedfilter.export=Exportar Filtros Guardados
+
+# Panel de Respaldo de Filtros de Color
+colorfilter.title=Respaldo de Filtros de Color
+colorfilter.import=Importar Filtros de Color
+colorfilter.export=Exportar Filtros de Color
+
+# Panel de Respaldo de Etiquetas
+tag.title=Respaldo de Etiquetas
+tag.import=Importar Etiquetas
+tag.export=Exportar Etiquetas
+
+# Panel de Reflexiones
+reflections.title=Reflexiones
+reflections.configfilters=Configurar Filtros
+reflections.configtransform=Configurar Detectores de Transformación
+
+# Panel de Reinicio
+reset.title=Reiniciar
+reset.all=Restablecer Todas las Configuraciones
+reset.all.confirm=¿Está seguro de que desea restablecer todas las configuraciones? ¡Esto incluye el diseño de la tabla!
+reset.all.confirm.title=Advertencia
+reset.clearlogs=Borrar los Registros
+
+# Panel de Notas
+notes.title=Notas
+notes.note0=Nota 0: Haga clic derecho en los encabezados de las columnas para cambiar la configuración.
+notes.note1=Nota 1: El registro extensivo puede afectar el rendimiento de Burp Suite.
+notes.note2=Nota 2: El registro automático no guarda solicitudes y respuestas. Solo el contenido de la tabla.\u0020
+notes.note3=Nota 3: Registro completo de solicitud/respuesta disponible en 'Opciones del Proyecto > Misc > Registro'
+notes.note4=Nota 4: Actualizar la extensión restablecerá la configuración de la tabla de registro.
+
+# Panel Acerca de
+about.developed=Desarrollado por: Corey Arthur ( @CoreyD97 )
+about.original=Originalmente por: Soroush Dalili ( @irsdl )
+about.twitter.corey=Sígueme (@CoreyD97) en Twitter
+about.twitter.irsdl=Sigue a Soroush (@irsdl) en Twitter
+about.twitter.ncc=Sigue a NCC Group en Twitter
+about.github.feature=Enviar Solicitud de Característica
+about.github.bug=Reportar un Problema
+about.features.title=Características
+about.features.list=\u2022 Registrar solicitudes de todas las herramientas\n\u2022 Definir filtros para buscar solicitudes\n\u2022 Crear reglas para resaltar solicitudes interesantes\n\u2022 Grep todas las entradas para patrones regex y extraer grupos coincidentes\n\u2022 Importar entradas desde WStalker, OWASP ZAP\n\u2022 Exportar entradas a elasticsearch, CSV\n\u2022 Multihilo\n\n¿Quieres una característica implementada? ¡Haz una solicitud usando los botones de arriba!\n¿Quieres ayudar a mejorar Logger++? ¡Envía un pull request!\n\n¿Te gusta la extensión? Házmelo saber dándole una estrella en GitHub.
+about.thanks.title=Agradecimientos a:
+about.thanks.list=Shaddy, ours-code, jselvi, jaesbit, wotgl, StanHVA, theblackturtle, cnotin, latacora-tomekr, JulianVolodia, jm-syn
+
+# Encabezados de Columna
+column.number=#
+column.tags=Etiquetas
+column.inscope=En Alcance
+column.complete=Completo
+column.tool=Herramienta
+column.ssl=SSL
+column.method=Método
+column.protocol=Protocolo
+column.hostname=Nombre de Host
+column.port=Puerto
+column.host=Host
+column.path=Ruta
+column.extension=Extensión
+column.query=Consulta
+column.pathquery=Ruta de Consulta
+column.url=URL
+column.hasparams=Tiene Parámetros
+column.status=Estado
+column.title=Título
+column.requestlength=Longitud de Solicitud
+column.responselength=Longitud de Respuesta
+column.inferredtype=Tipo Inferido
+column.comment=Comentario
+column.paramcount=Conteo de Parámetros
+column.params=Parámetros
+column.reflectedparams=Parámetros Reflejados
+column.reflectioncount=Conteo de Reflexión
+column.origin=Encabezado de Origen
+column.mimetype=Tipo MIME
+column.newcookies=Nuevas Cookies
+column.requesttime=Tiempo de Solicitud
+column.responsetime=Tiempo de Respuesta
+column.responsehash=Hash de Respuesta
+column.rtt=RTT (ms)
+column.listenerinterface=Interfaz del Listener del Proxy
+column.clientip=IP del Cliente del Proxy
+column.responsecontenttype=Tipo de Contenido de Respuesta
+column.querystring=¿Cadena de Consulta?
+column.bodyparams=¿Parámetros del Cuerpo?
+column.sentcookie=¿Cookie Enviada?
+column.sentcookies=Cookies Enviadas
+column.cookiejar=¿Contiene jar de cookies?
+column.requesttype=Tipo de Solicitud
+column.referrer=Referente
+column.redirect=Redirección
+column.setcookie=¿Set-Cookie?
+column.requestbody=Cuerpo de Solicitud
+column.requestbodylength=Longitud del Cuerpo de Solicitud
+column.requestheaders=Encabezados de Solicitud
+column.responsebody=Cuerpo de Respuesta
+column.responsebodylength=Longitud del Cuerpo de Respuesta
+column.responseheaders=Encabezados de Respuesta
+
+# Botones Comunes
+button.ok=Aceptar
+button.cancel=Cancelar
+button.save=Guardar
+button.delete=Eliminar
+button.close=Cerrar
+button.enable=Activar
+button.disable=Desactivar
+button.import=Importar
+button.export=Exportar
+
+# Mensajes Comunes
+message.warning=Advertencia
+message.error=Error
+message.success=Éxito
+message.confirm=Confirmar
+
+# Mensajes del Exportador Elastic
+elastic.warning.change=Advertencia: Cambiar las preferencias mientras se ejecuta deshabilitará el servicio de carga y borrará todas las cargas pendientes.


### PR DESCRIPTION
- Create i18n infrastructure with Messages utility class
- Add resource bundles for English (default) and Spanish
- Externalize UI strings in PreferencesPanel, LoggerMenu, and AboutPanel
- Support runtime locale switching
- Add framework for additional languages (French, German, Japanese, Chinese, Portuguese)
- Include comprehensive INTERNATIONALIZATION.md documentation

Modified files:
- src/main/java/com/nccgroup/loggerplusplus/preferences/PreferencesPanel.java
- src/main/java/com/nccgroup/loggerplusplus/util/userinterface/LoggerMenu.java
- src/main/java/com/nccgroup/loggerplusplus/about/AboutPanel.java

New files:
- src/main/java/com/nccgroup/loggerplusplus/i18n/Messages.java
- src/main/resources/i18n/messages.properties
- src/main/resources/i18n/messages_es.properties
- INTERNATIONALIZATION.md

Resolves #4